### PR TITLE
[fix] sfdc_credentials variable

### DIFF
--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -4,13 +4,13 @@ var sfdc_credentials = new Preferences('sfdc.iot.explorer.tool');
 exports.save = function(uname, passwd, is_sandbox) {
     sfdc_credentials.username = uname;
     sfdc_credentials.password = passwd;
-    sfdc_credentials.token = is_sandbox;
+    sfdc_credentials.is_sandbox = is_sandbox;
 }
 
 exports.clear = function () {
     sfdc_credentials.username = '';
     sfdc_credentials.password = '';
-    sfdc_credentials.token = '';
+    sfdc_credentials.is_sandbox = '';
 }
 
 exports.get = function () {


### PR DESCRIPTION
`is_sandbox` の値を保存している `sfdc_credentials` の変数が `token` となっていたため、Sandboxへのログインがうまく動作していなかったため、その修正です。